### PR TITLE
Jperf 421 move legend to the right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 
 ### Fixed
 - Do not throw negative phase exception in `WaterfallChart` when `responseEnd` is before `responseStart`. Fix [JPERF-416].
+- Move the legend on the distribution chart to the side. Resolve [JPERF-421].
+- Group labels in distribution chart by cohort. Resolve [JPERF-421].
 
 [JPERF-416]: https://ecosystem.atlassian.net/browse/JPERF-416
+[JPERF-421]: https://ecosystem.atlassian.net/browse/JPERF-421
 
 ## [3.1.1] - 2019-01-23
 [3.1.1]: https://github.com/atlassian/report/compare/release-3.1.0...release-3.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 
 ### Fixed
 - Do not throw negative phase exception in `WaterfallChart` when `responseEnd` is before `responseStart`. Fix [JPERF-416].
+- Move the legend on the distribution chart to the side. Resolve [JPERF-421].
+- Group labels in distribution chart by cohort. Resolve [JPERF-421].
 
 [JPERF-416]: https://ecosystem.atlassian.net/browse/JPERF-416
+[JPERF-421]: https://ecosystem.atlassian.net/browse/JPERF-421
 
 ## [3.1.1] - 2019-01-23
 [3.1.1]: https://github.com/atlassian/report/compare/release-3.1.0...release-3.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 [JPERF-416]: https://ecosystem.atlassian.net/browse/JPERF-416
 [JPERF-421]: https://ecosystem.atlassian.net/browse/JPERF-421
 
+### Fixed
+- Do not throw negative phase exception in `WaterfallChart` when `responseEnd` is before `responseStart`. Fix [JPERF-416].
+
+[JPERF-416]: https://ecosystem.atlassian.net/browse/JPERF-416
+
 ## [3.1.1] - 2019-01-23
 [3.1.1]: https://github.com/atlassian/report/compare/release-3.1.0...release-3.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 [JPERF-416]: https://ecosystem.atlassian.net/browse/JPERF-416
 [JPERF-421]: https://ecosystem.atlassian.net/browse/JPERF-421
 
+### Fixed
+- Do not throw negative phase exception in `WaterfallChart` when `responseEnd` is before `responseStart`. Fix [JPERF-416].
+
+[JPERF-416]: https://ecosystem.atlassian.net/browse/JPERF-416
+
 ## [3.1.1] - 2019-01-23
 [3.1.1]: https://github.com/atlassian/report/compare/release-3.1.0...release-3.1.1
 

--- a/src/main/resources/com/atlassian/performance/tools/report/distribution/distribution-comparison-template.html
+++ b/src/main/resources/com/atlassian/performance/tools/report/distribution/distribution-comparison-template.html
@@ -67,6 +67,10 @@
                         }
                     ]
                 },
+                legend: {
+                    display: true,
+                    position: 'right'
+                },
                 elements: {
                     line: {
                         tension: 0

--- a/src/test/resources/com/atlassian/performance/tools/report/distribution/expected-distribution-comparison.html
+++ b/src/test/resources/com/atlassian/performance/tools/report/distribution/expected-distribution-comparison.html
@@ -67,6 +67,10 @@
                         }
                     ]
                 },
+                legend: {
+                    display: true,
+                    position: 'right'
+                },
                 elements: {
                     line: {
                         tension: 0


### PR DESCRIPTION
As a part of #6 the legend was moved to the side, which was not included in the original PR for some reason. Addressing that mistake in this PR.