### PR TITLE
Mark Release 3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@ Adding a requirement of a major version of a dependency is breaking a contract.
 Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
-[Unreleased]: https://github.com/atlassian/report/compare/release-3.6.0...master
+[Unreleased]: https://github.com/atlassian/report/compare/release-3.6.1...master
+
+## [3.6.1] - 2019-08-09
+[3.6.1]: https://github.com/atlassian/report/compare/release-3.6.0...release-3.6.1
 
 ### Fixed
 - Make nonparametric judges more specific about the failure type. Resolves [JPERF-551].


### PR DESCRIPTION
I'll merge when the files are available here: https://packages.atlassian.com/maven-public/com/atlassian/performance/tools/report/3.6.1/