### PR TITLE
Mark 3.8.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,10 @@ Adding a requirement of a major version of a dependency is breaking a contract.
 Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
-[Unreleased]: https://github.com/atlassian/report/compare/release-3.8.1...master
+[Unreleased]: https://github.com/atlassian/report/compare/release-3.8.2...master
 
+## [3.8.2] - 2020-04-06
+[3.8.2]: https://github.com/atlassian/report/compare/release-3.8.1...release-3.8.2
 ### Fixed
 - The tooltips shown on hover in timeline chart are now correct. Resolve [JPERF-614].
 


### PR DESCRIPTION
Released artifacts: https://packages.atlassian.com/maven-public/com/atlassian/performance/tools/report/3.8.2/