### PR TITLE
JPERF-714: Use a proper repository access token for Publish Test Report GHA step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       if: always()
       uses: scacap/action-surefire-report@v1.0.5
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.REPOSITORY_ACCESS_TOKEN }}
         report_paths: '**/build/test-results/*/TEST-*.xml'
     - name: Upload test reports
       if: always()


### PR DESCRIPTION
That should make it possible for the step to run as part of PRs from forked repos