### PR TITLE
JPERF-714: Remove Publish Test Report GHA step altogether

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,6 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('gradle') }}
     - name: Build
       run: ./gradlew build
-    - name: Publish Test Report
-      if: always()
-      uses: scacap/action-surefire-report@v1.0.5
-      with:
-        github_token: ${{ secrets.REPOSITORY_ACCESS_TOKEN }}
-        report_paths: '**/build/test-results/*/TEST-*.xml'
     - name: Upload test reports
       if: always()
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
The https://github.com/ScaCap/action-surefire-report action has a bug that prevents it from running properly on PRs from forks: https://github.com/ScaCap/action-surefire-report/issues/31.