### PR TITLE
JPERF-832 Restore missing log label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,16 @@ Adding a requirement of a major version of a dependency is breaking a contract.
 Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
-[Unreleased]: https://github.com/atlassian/report/compare/release-3.11.3...master
+[Unreleased]: https://github.com/atlassian/report/compare/release-3.11.4...master
+
+### Fixed
+- Restore missing log label in failed regression test
+
+## [3.11.4] - 2022-10-14
+[3.11.4]: https://github.com/atlassian/report/compare/release-3.11.3...release-3.11.4
+
+### Changed
+- Make log message for failed regression test more user friendly
 
 ## [3.11.3] - 2022-06-23
 [3.11.3]: https://github.com/atlassian/report/compare/release-3.11.2...release-3.11.3

--- a/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/RelativeNonparametricPerformanceJudge.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/RelativeNonparametricPerformanceJudge.kt
@@ -62,7 +62,7 @@ class RelativeNonparametricPerformanceJudge(
         val test = ShiftedDistributionRegressionTest(baseline, experiment, mwAlpha = significance, ksAlpha = 0.0)
         return if (test.isExperimentRegressed(toleranceRatio.toDouble())) {
             val confidenceLevelPercent = (1.0 - significance).toPercentage(decimalPlaces = 2)
-            val message = "There is a regression with $confidenceLevelPercent confidence level. Regression is larger than allowed ${toleranceRatio.toPercentage(decimalPlaces = 2)} tolerance"
+            val message = "There is a regression in [$label] with $confidenceLevelPercent confidence level. Regression is larger than allowed ${toleranceRatio.toPercentage(decimalPlaces = 2)} tolerance"
             ActionReport(
                 report = FailedActionJunitReport(testName = reportName, assertion = message),
                 action = action,


### PR DESCRIPTION
Because of accidentally removed [$label] in log entry, SmartRerunTest in JPT was failing