### PR TITLE
Make Verdict.Builder easy to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,10 @@ Dropping a requirement of a major version of a dependency is a new contract.
 [Unreleased]: https://github.com/atlassian/report/compare/release-3.11.5...master
 
 ### Added
-- Add Verdict.Builder to allow failedReports to be set and make it more flexible to use. Especially in unit tests in projects using this library.
+- Add `Verdict.Builder` for easier `Verdict` assembly and `failedActions` injection.
 
 ### Deprecated
-- Mark Verdict.Builder constructor as deprecated.
+- Mark `Verdict` constructor as deprecated.
  
 ## [3.11.5] - 2022-10-20
 [3.11.5]: https://github.com/atlassian/report/compare/release-3.11.4...release-3.11.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 
 ### Deprecated
 - Mark `Verdict` constructor as deprecated.
+
+### Fixed
+- Fix `Verdict.plus` dropping the `failedActions`.
  
 ## [3.11.5] - 2022-10-20
 [3.11.5]: https://github.com/atlassian/report/compare/release-3.11.4...release-3.11.5

--- a/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/ErrorsJudge.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/ErrorsJudge.kt
@@ -24,14 +24,14 @@ class ErrorsJudge {
         stats: Stats,
         criteria: Map<ActionType<*>, ErrorCriteria>
     ): Verdict {
-        val testReports = mutableListOf<JUnitReport>()
+        val verdict = Verdict.Builder()
 
         for ((action, errorCriteria) in criteria) {
             val acceptableErrorCount = errorCriteria.acceptableErrorCount
             val errorCount = stats.errors[action.label] ?: 0
 
             if (errorCount > acceptableErrorCount) {
-                testReports.add(
+                verdict.addReport(
                     FailedAssertionJUnitReport(
                         testMethodName(action, stats.cohort),
                         "The '${action.label}' action has failed $errorCount times. " +
@@ -40,11 +40,11 @@ class ErrorsJudge {
                     )
                 )
             } else {
-                testReports.add(SuccessfulJUnitReport(testMethodName(action, stats.cohort)))
+                verdict.addReport(SuccessfulJUnitReport(testMethodName(action, stats.cohort)))
             }
         }
 
-        return Verdict.Builder(reports = testReports).build()
+        return verdict.build()
     }
 
     private fun testMethodName(

--- a/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/FailureJudge.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/FailureJudge.kt
@@ -9,15 +9,13 @@ class FailureJudge {
 
     fun judge(
         failure: Exception?
-    ): Verdict = Verdict
-        .Builder(
-            reports = listOf(
-                if (failure == null) {
-                    SuccessfulJUnitReport(testName)
-                } else {
-                    ExceptionJUnitReport(testName, failure)
-                }
-            )
+    ): Verdict = Verdict.Builder()
+        .addReport(
+            if (failure == null) {
+                SuccessfulJUnitReport(testName)
+            } else {
+                ExceptionJUnitReport(testName, failure)
+            }
         )
         .build()
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/NodeBalanceJudge.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/NodeBalanceJudge.kt
@@ -11,15 +11,13 @@ class NodeBalanceJudge(
 ) {
     fun judge(nodeCounts: Map<String, Int>): Verdict {
         if (nodeCounts.size != criteria.nodes) {
-            return Verdict
-                .Builder(
-                    reports = listOf<JUnitReport>(
-                        FailedAssertionJUnitReport(
-                            testName = testMethodName(cohort),
-                            assertion = "Results are not available for some nodes. "
-                                + "There should be ${criteria.nodes} results but is ${nodeCounts.size}. "
-                                + "See node's distribution : $nodeCounts"
-                        )
+            return Verdict.Builder()
+                .addReport(
+                    FailedAssertionJUnitReport(
+                        testName = testMethodName(cohort),
+                        assertion = "Results are not available for some nodes. "
+                            + "There should be ${criteria.nodes} results but is ${nodeCounts.size}. "
+                            + "See node's distribution : $nodeCounts"
                     )
                 )
                 .build()
@@ -28,23 +26,17 @@ class NodeBalanceJudge(
         val maxVirtualUsers = nodeCounts.maxBy { entry -> entry.value }!!
         val minVirtualUsers = nodeCounts.minBy { entry -> entry.value }!!
         val diff = maxVirtualUsers.value - minVirtualUsers.value
-        if (diff <= criteria.maxVirtualUsersImbalance) {
-            return Verdict
-                .Builder(
-                    reports = listOf<JUnitReport>(
-                        SuccessfulJUnitReport(testMethodName(cohort))
-                    )
-                )
+        return if (diff <= criteria.maxVirtualUsersImbalance) {
+            Verdict.Builder()
+                .addReport(SuccessfulJUnitReport(testMethodName(cohort)))
                 .build()
         } else {
-            return Verdict
-                .Builder(
-                    reports = listOf<JUnitReport>(
-                        FailedAssertionJUnitReport(
-                            testName = testMethodName(cohort),
-                            assertion = "More virtual users were testing one node (${maxVirtualUsers.key}) than another (${minVirtualUsers.key}). " +
+            Verdict.Builder()
+                .addReport(
+                    FailedAssertionJUnitReport(
+                        testName = testMethodName(cohort),
+                        assertion = "More virtual users were testing one node (${maxVirtualUsers.key}) than another (${minVirtualUsers.key}). " +
                                 "See node's distribution : $nodeCounts"
-                        )
                     )
                 )
                 .build()

--- a/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/RelativeNonparametricPerformanceJudge.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/RelativeNonparametricPerformanceJudge.kt
@@ -21,8 +21,7 @@ class RelativeNonparametricPerformanceJudge(
         baselineResult: EdibleResult,
         experimentResult: EdibleResult
     ): Verdict {
-        val testReports = mutableListOf<JUnitReport>()
-        val failedActions = mutableListOf<ActionType<*>>()
+        val verdict = Verdict.Builder()
         for ((action, toleranceRatio) in toleranceRatios) {
             val actionReport = judge(
                 action,
@@ -30,12 +29,12 @@ class RelativeNonparametricPerformanceJudge(
                 baselineResult,
                 experimentResult
             )
-            testReports.add(actionReport.report)
+            verdict.addReport(actionReport.report)
             if (actionReport.nonExceptionalFailure) {
-                failedActions.add(actionReport.action)
+                verdict.addFailedAction(actionReport.action)
             }
         }
-        return Verdict.Builder(reports = testReports).failedActions(failedActions).build()
+        return verdict.build()
     }
 
     private fun judge(

--- a/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/RelativeNonparametricStabilityJudge.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/RelativeNonparametricStabilityJudge.kt
@@ -20,24 +20,19 @@ class RelativeNonparametricStabilityJudge(
         baselineResult: EdibleResult,
         experimentResult: EdibleResult
     ): Verdict {
-        val testReports = mutableListOf<JUnitReport>()
-        val failedActions = mutableListOf<ActionType<*>>()
+        val verdict = Verdict.Builder()
         actions.forEach { action ->
             val actionReport = judge(
                 action,
                 baselineResult,
                 experimentResult
             )
-            testReports.add(actionReport.report)
+            verdict.addReport(actionReport.report)
             if (actionReport.nonExceptionalFailure) {
-                failedActions.add(actionReport.action)
+                verdict.addFailedAction(actionReport.action)
             }
         }
-
-        return Verdict
-            .Builder(reports = testReports)
-            .failedActions(failedActions = failedActions)
-            .build()
+        return verdict.build()
     }
 
     private fun judge(

--- a/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/RelativePerformanceStabilityJudge.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/RelativePerformanceStabilityJudge.kt
@@ -26,23 +26,22 @@ class RelativePerformanceStabilityJudge {
         baselineStats: Stats,
         experimentStats: Stats
     ): Verdict {
-        return Verdict
-            .Builder(
-                reports = maxDispersionDifferences.map { (action, maxDispersionDifference) ->
-                    val label = action.label
-                    val experimentDispersion = dispersions(experimentStats, label)
-                    val baselineDispersion = dispersions(baselineStats, label)
-                    val regression = experimentDispersion - baselineDispersion
-                    val reportName = "Stability regression for $label ${experimentStats.cohort} vs ${baselineStats.cohort}"
-                    return@map if (regression > maxDispersionDifference) {
-                        val message = "$label $regression stability regression overcame $maxDispersionDifference threshold"
-                        FailedAssertionJUnitReport(reportName, message)
-                    } else {
-                        SuccessfulJUnitReport(testName = reportName)
-                    }
-                }
-            )
-            .build()
+        val verdict = Verdict.Builder()
+        maxDispersionDifferences.forEach { (action, maxDispersionDifference) ->
+            val label = action.label
+            val experimentDispersion = dispersions(experimentStats, label)
+            val baselineDispersion = dispersions(baselineStats, label)
+            val regression = experimentDispersion - baselineDispersion
+            val reportName = "Stability regression for $label ${experimentStats.cohort} vs ${baselineStats.cohort}"
+            val report = if (regression > maxDispersionDifference) {
+                val message = "$label $regression stability regression overcame $maxDispersionDifference threshold"
+                FailedAssertionJUnitReport(reportName, message)
+            } else {
+                SuccessfulJUnitReport(testName = reportName)
+            }
+            verdict.addReport(report)
+        }
+        return verdict.build()
     }
 
     private fun dispersions(stats: Stats, label: String) =

--- a/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/RelativeTypicalPerformanceJudge.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/RelativeTypicalPerformanceJudge.kt
@@ -27,9 +27,9 @@ class RelativeTypicalPerformanceJudge {
         baselineStats: Stats,
         experimentStats: Stats
     ): Verdict {
-        val testReports = mutableListOf<JUnitReport>()
+        val verdict = Verdict.Builder()
         for ((action, toleranceRatio) in toleranceRatios) {
-            testReports.add(
+            verdict.addReport(
                 judge(
                     action,
                     toleranceRatio,
@@ -38,7 +38,7 @@ class RelativeTypicalPerformanceJudge {
                 )
             )
         }
-        return Verdict.Builder(reports = testReports).build()
+        return verdict.build()
     }
 
     private fun judge(

--- a/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/SampleSizeJudge.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/SampleSizeJudge.kt
@@ -1,11 +1,10 @@
 package com.atlassian.performance.tools.report.api.judge
 
 import com.atlassian.performance.tools.jiraactions.api.ActionType
-import com.atlassian.performance.tools.report.api.result.InteractionStats
 import com.atlassian.performance.tools.report.api.SampleSizeCriteria
 import com.atlassian.performance.tools.report.api.junit.FailedAssertionJUnitReport
-import com.atlassian.performance.tools.report.api.junit.JUnitReport
 import com.atlassian.performance.tools.report.api.junit.SuccessfulJUnitReport
+import com.atlassian.performance.tools.report.api.result.InteractionStats
 import com.atlassian.performance.tools.report.api.result.Stats
 import com.atlassian.performance.tools.report.result.PerformanceStats
 
@@ -24,20 +23,21 @@ class SampleSizeJudge {
         stats: Stats,
         criteria: Map<ActionType<*>, SampleSizeCriteria>
     ): Verdict {
+        val verdict = Verdict.Builder()
         val sampleSizes = stats.sampleSizes
-        val testReports = mutableListOf<JUnitReport>()
         for ((action, sampleCriteria) in criteria) {
             val sampleSize = sampleSizes[action.label] ?: 0
             val minimumSampleSize = sampleCriteria.minimumSampleSize
-            if (sampleSize < minimumSampleSize) {
+            val report = if (sampleSize < minimumSampleSize) {
                 val message = "The sample size of ${stats.cohort} ${action.label} is $sampleSize," +
                     " which is under the minimum threshold of $minimumSampleSize"
-                testReports.add(FailedAssertionJUnitReport(testMethodName(stats.cohort, action), message))
+                FailedAssertionJUnitReport(testMethodName(stats.cohort, action), message)
             } else {
-                testReports.add(SuccessfulJUnitReport(testMethodName(stats.cohort, action)))
+                SuccessfulJUnitReport(testMethodName(stats.cohort, action))
             }
+            verdict.addReport(report)
         }
-        return Verdict.Builder(reports = testReports).build()
+        return verdict.build()
     }
 
     private fun testMethodName(

--- a/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/Verdict.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/Verdict.kt
@@ -79,7 +79,10 @@ class Verdict internal constructor(
         logger.info("Performance results are accepted")
     }
 
-    operator fun plus(other: Verdict) = Builder(reports = reports + other.reports).build()
+    operator fun plus(other: Verdict) = Builder()
+        .addReports(reports)
+        .addReports(other.reports)
+        .build()
 
     private fun checkIfNoReportIsMissing(
         expectedReportCount: Int?

--- a/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/Verdict.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/Verdict.kt
@@ -17,7 +17,10 @@ class Verdict internal constructor(
 ) {
     private val logger = LogManager.getLogger(this::class.java)
 
-    @Deprecated(message = "Use Builder instead", replaceWith = ReplaceWith("Verdict.Builder(reports).build()"))
+    @Deprecated(
+        message = "Use Builder instead",
+        replaceWith = ReplaceWith("Verdict.Builder().addReports(reports).build()")
+    )
     constructor(
         reports: List<JUnitReport>
     ) : this(
@@ -28,16 +31,24 @@ class Verdict internal constructor(
     /**
      * Since 3.12.0
      */
-    class Builder(reports: List<JUnitReport>) {
+    class Builder {
+        private var reports: MutableList<JUnitReport> = ArrayList()
         private var failedActions: MutableList<ActionType<*>> = ArrayList()
-        private var reports: MutableList<JUnitReport> = ArrayList(reports)
 
-        fun failedActions(failedActions: List<ActionType<*>>): Builder = apply {
-            this.failedActions = ArrayList(failedActions)
+        fun addReport(report: JUnitReport): Builder = apply {
+            reports.add(report)
         }
 
         fun addReports(reports: List<JUnitReport>): Builder = apply {
             this.reports.addAll(reports)
+        }
+
+        fun addFailedAction(failedAction: ActionType<*>): Builder = apply {
+            this.failedActions.add(failedAction)
+        }
+
+        fun addFailedActions(failedActions: List<ActionType<*>>): Builder = apply {
+            this.failedActions.addAll(failedActions)
         }
 
         fun build(): Verdict {

--- a/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/VirtualUsersJudge.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/VirtualUsersJudge.kt
@@ -2,7 +2,6 @@ package com.atlassian.performance.tools.report.api.judge
 
 import com.atlassian.performance.tools.report.api.PerformanceCriteria
 import com.atlassian.performance.tools.report.api.junit.FailedAssertionJUnitReport
-import com.atlassian.performance.tools.report.api.junit.JUnitReport
 import com.atlassian.performance.tools.report.api.junit.SuccessfulJUnitReport
 
 class VirtualUsersJudge(
@@ -14,27 +13,18 @@ class VirtualUsersJudge(
     ): Verdict {
         val expected = criteria.virtualUserLoad.virtualUsers
         val active = nodeCounts.values.sum()
-        if (expected - active <= criteria.maxInactiveVirtualUsers) {
-            return Verdict
-                .Builder(
-                    reports = listOf<JUnitReport>(
-                        SuccessfulJUnitReport(testMethodName(cohort))
-                    )
-                )
-                .build()
+        val report = if (expected - active <= criteria.maxInactiveVirtualUsers) {
+            SuccessfulJUnitReport(testMethodName(cohort))
         } else {
-            return Verdict
-                .Builder(
-                    reports = listOf<JUnitReport>(
-                        FailedAssertionJUnitReport(
-                            testMethodName(cohort),
-                            "$expected virtual users were expected, but only $active "
-                                + "logged in to the JIRA. It's below maxInactiveVirtualUsers criteria (${criteria.maxInactiveVirtualUsers})"
-                        )
-                    )
-                )
-                .build()
+            FailedAssertionJUnitReport(
+                testMethodName(cohort),
+                "$expected virtual users were expected, but only $active "
+                    + "logged in to the JIRA. It's below maxInactiveVirtualUsers criteria (${criteria.maxInactiveVirtualUsers})"
+            )
         }
+        return Verdict.Builder()
+            .addReport(report)
+            .build()
     }
 
     private fun testMethodName(


### PR DESCRIPTION
There's much less ceremony around the Builder constructor and forced `listOf`.
It also enables nicer refactors of the judges.
See such mini-refactors in `RelativePerformanceStabilityJudge` and `RelativeNonparametricPerformanceJudge`.

PS. Fix `Verdict.plus` dropping the failedActions.