### PR TITLE
JPERF-845 Deprecate RelativeNonparametricStabilityJudge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/report/compare/release-3.12.0...master
 
+### Deprecated
+- Mark `RelativeNonparametricStabilityJudge` as deprecated.
+
 ## [3.12.0] - 2022-10-27
 [3.12.0]: https://github.com/atlassian/report/compare/release-3.11.5...release-3.12.0
 

--- a/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/RelativeNonparametricStabilityJudge.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/api/judge/RelativeNonparametricStabilityJudge.kt
@@ -4,11 +4,11 @@ import com.atlassian.performance.tools.jiraactions.api.ActionType
 import com.atlassian.performance.tools.report.ActionMetricsReader
 import com.atlassian.performance.tools.report.api.ShiftedDistributionRegressionTest
 import com.atlassian.performance.tools.report.api.junit.FailedAssertionJUnitReport
-import com.atlassian.performance.tools.report.api.junit.JUnitReport
 import com.atlassian.performance.tools.report.api.junit.SuccessfulJUnitReport
 import com.atlassian.performance.tools.report.api.result.EdibleResult
 import com.atlassian.performance.tools.report.junit.FailedActionJunitReport
 
+@Deprecated("The verdict is misleading when it reports data shape differences due to single big difference, e.g. on P100")
 class RelativeNonparametricStabilityJudge(
     private val significance: Double
 ) {


### PR DESCRIPTION
RelativeNonparametricStabilityJudge is too sensitive and it causes false positive failures.