### PR TITLE
Mark 3.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@ Adding a requirement of a major version of a dependency is breaking a contract.
 Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
-[Unreleased]: https://github.com/atlassian/report/compare/release-3.12.0...master
+[Unreleased]: https://github.com/atlassian/report/compare/release-3.13.0...master
+
+## [3.13.0] - 2022-12-16
+[3.13.0]: https://github.com/atlassian/report/compare/release-3.12.0...release-3.13.0
 
 ### Deprecated
 - Mark `RelativeNonparametricStabilityJudge` as deprecated.


### PR DESCRIPTION
Released using CI: https://github.com/atlassian/report/actions/runs/3714769814
Available under: https://packages.atlassian.com/maven-central/com/atlassian/performance/tools/report/3.13.0/