### PR TITLE
Mark 3.16.1 and 3.16.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,14 +24,23 @@ Adding a requirement of a major version of a dependency is breaking a contract.
 Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
-[Unreleased]: https://github.com/atlassian/report/compare/release-3.16.0...master
+[Unreleased]: https://github.com/atlassian/report/compare/release-3.16.2...master
+
+## [3.16.2] - 2023-10-06
+[3.16.2]: https://github.com/atlassian/report/compare/release-3.16.1...release-3.16.2
+
+### Fixed
+- Make `LatencyImpactClassifier` thread safe. Unblock [JPERF-1263].
+
+[JPERF-1263]: https://ecosystem.atlassian.net/browse/JPERF-1263
+
+## [3.16.1] - 2023-08-23
+[3.16.1]: https://github.com/atlassian/report/compare/release-3.16.0...release-3.16.1
 
 ### Fixed
 - Don't throw when asking for shifts in `ShiftedDistributionRegressionTest`. Fix [JPERF-1256].
-- Make `LatencyImpactClassifier` thread safe. Unblock [JPERF-1263].
 
 [JPERF-1256]: https://ecosystem.atlassian.net/browse/JPERF-1256
-[JPERF-1263]: https://ecosystem.atlassian.net/browse/JPERF-1263
 
 ## [3.16.0] - 2023-08-10
 [3.16.0]: https://github.com/atlassian/report/compare/release-3.15.0...release-3.16.0


### PR DESCRIPTION
https://packages.atlassian.com/maven-central-local/com/atlassian/performance/tools/report/3.16.1/
https://packages.atlassian.com/maven-central-local/com/atlassian/performance/tools/report/3.16.2/