### PR TITLE
JPERF-1401: Use JsonProvider instead of Json to make ChartLine faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/report/compare/release-3.16.2...master
 
+### Fixed
+- Use `JsonProvider` instead of `Json` to make `ChartLine` faster. Fix [JPERF-1401]
+
+[JPERF-1401]: https://ecosystem.atlassian.net/browse/JPERF-1401
+
 ## [3.16.2] - 2023-10-06
 [3.16.2]: https://github.com/atlassian/report/compare/release-3.16.1...release-3.16.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Dropping a requirement of a major version of a dependency is a new contract.
 [Unreleased]: https://github.com/atlassian/report/compare/release-3.16.2...master
 
 ### Fixed
-- Use `JsonProvider` instead of `Json` to make `ChartLine` faster. Fix [JPERF-1401]
+- Speed up all JSON code, by reusing a `JsonProvider` instance. Fix [JPERF-1401].
 
 [JPERF-1401]: https://ecosystem.atlassian.net/browse/JPERF-1401
 

--- a/src/main/kotlin/com/atlassian/performance/tools/report/JsonProviderSingleton.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/JsonProviderSingleton.kt
@@ -1,0 +1,8 @@
+package com.atlassian.performance.tools.report
+
+import javax.json.spi.JsonProvider
+
+internal object JsonProviderSingleton {
+
+    val JSON: JsonProvider = JsonProvider.provider()
+}

--- a/src/main/kotlin/com/atlassian/performance/tools/report/chart/Chart.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/chart/Chart.kt
@@ -1,6 +1,6 @@
 package com.atlassian.performance.tools.report.chart
 
-import javax.json.Json
+import com.atlassian.performance.tools.report.JsonProviderSingleton.JSON
 import javax.json.JsonArrayBuilder
 import javax.json.JsonObject
 
@@ -9,14 +9,14 @@ internal class Chart<X>(
 ) where X : Comparable<X> {
 
     fun toJson(): JsonObject {
-        val dataBuilder = Json.createObjectBuilder()
-        dataBuilder.add("labels", Json.createArrayBuilder(getLabels()).build())
+        val dataBuilder = JSON.createObjectBuilder()
+        dataBuilder.add("labels", JSON.createArrayBuilder(getLabels()).build())
         dataBuilder.add("datasets", getLines())
         return dataBuilder.build()
     }
 
     private fun getLines(): JsonArrayBuilder {
-        val linesBuilder = Json.createArrayBuilder()
+        val linesBuilder = JSON.createArrayBuilder()
         lines.forEach {
             linesBuilder.add(it.toJson())
         }

--- a/src/main/kotlin/com/atlassian/performance/tools/report/chart/ChartAxis.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/chart/ChartAxis.kt
@@ -1,6 +1,6 @@
 package com.atlassian.performance.tools.report.chart
 
-import javax.json.Json
+import com.atlassian.performance.tools.report.JsonProviderSingleton.JSON
 import javax.json.JsonObject
 
 internal data class ChartAxis(
@@ -8,7 +8,7 @@ internal data class ChartAxis(
     val text: String
 ) {
     fun toJson(): JsonObject {
-        return Json.createObjectBuilder()
+        return JSON.createObjectBuilder()
             .add("id", id)
             .add("text", text)
             .build()

--- a/src/main/kotlin/com/atlassian/performance/tools/report/chart/ChartLine.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/chart/ChartLine.kt
@@ -2,8 +2,8 @@ package com.atlassian.performance.tools.report.chart
 
 import com.atlassian.performance.tools.report.Point
 import java.util.*
-import javax.json.Json
 import javax.json.JsonObject
+import javax.json.spi.JsonProvider
 
 internal class ChartLine<X>(
     val data: List<Point<X>>,
@@ -14,20 +14,21 @@ internal class ChartLine<X>(
     private val cohort: String = ""
 ) where X : Comparable<X> {
     fun toJson(): JsonObject {
-        val dataBuilder = Json.createArrayBuilder()
+        val json = JsonProvider.provider()
+        val dataBuilder = json.createArrayBuilder()
         data.forEach { point ->
             dataBuilder.add(
-                Json.createObjectBuilder()
+                json.createObjectBuilder()
                     .add("x", point.labelX())
                     .add("y", point.y)
                     .build()
             )
         }
-        val chartDataBuilder = Json.createObjectBuilder()
+        val chartDataBuilder = json.createObjectBuilder()
         chartDataBuilder.add("type", type)
         chartDataBuilder.add("label", label)
 
-        if (!cohort.isBlank()) {
+        if (cohort.isNotBlank()) {
             chartDataBuilder.add("cohort", cohort)
         }
 

--- a/src/main/kotlin/com/atlassian/performance/tools/report/chart/ChartLine.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/chart/ChartLine.kt
@@ -1,9 +1,9 @@
 package com.atlassian.performance.tools.report.chart
 
+import com.atlassian.performance.tools.report.JsonProviderSingleton.JSON
 import com.atlassian.performance.tools.report.Point
 import java.util.*
 import javax.json.JsonObject
-import javax.json.spi.JsonProvider
 
 internal class ChartLine<X>(
     val data: List<Point<X>>,
@@ -14,17 +14,16 @@ internal class ChartLine<X>(
     private val cohort: String = ""
 ) where X : Comparable<X> {
     fun toJson(): JsonObject {
-        val json = JsonProvider.provider()
-        val dataBuilder = json.createArrayBuilder()
+        val dataBuilder = JSON.createArrayBuilder()
         data.forEach { point ->
             dataBuilder.add(
-                json.createObjectBuilder()
+                JSON.createObjectBuilder()
                     .add("x", point.labelX())
                     .add("y", point.y)
                     .build()
             )
         }
-        val chartDataBuilder = json.createObjectBuilder()
+        val chartDataBuilder = JSON.createObjectBuilder()
         chartDataBuilder.add("type", type)
         chartDataBuilder.add("label", label)
 

--- a/src/main/kotlin/com/atlassian/performance/tools/report/chart/MeanLatencyChart.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/chart/MeanLatencyChart.kt
@@ -1,6 +1,7 @@
 package com.atlassian.performance.tools.report.chart
 
 import com.atlassian.performance.tools.io.api.ensureParentDirectory
+import com.atlassian.performance.tools.report.JsonProviderSingleton.JSON
 import com.atlassian.performance.tools.report.JsonStyle
 import com.atlassian.performance.tools.report.MeanAggregator
 import com.atlassian.performance.tools.report.api.result.Stats
@@ -12,7 +13,6 @@ import java.time.format.DateTimeFormatter.ofLocalizedDateTime
 import java.time.format.DateTimeFormatterBuilder
 import java.time.format.FormatStyle
 import java.time.temporal.ChronoField.NANO_OF_SECOND
-import javax.json.Json
 import javax.json.JsonArray
 import javax.json.JsonObject
 
@@ -43,16 +43,16 @@ internal class MeanLatencyChart {
 
     private fun toJson(
         latencies: List<CohortMeanLatency>
-    ): JsonObject = Json.createObjectBuilder()
-        .add("labels", Json.createArrayBuilder(latencies.map { prettyPrint(it.cohort) }).build())
-        .add("datasets", Json.createArrayBuilder().add(getDataset(latencies)).build())
+    ): JsonObject = JSON.createObjectBuilder()
+        .add("labels", JSON.createArrayBuilder(latencies.map { prettyPrint(it.cohort) }).build())
+        .add("datasets", JSON.createArrayBuilder().add(getDataset(latencies)).build())
         .build()
 
     private fun getDataset(
         latencies: List<CohortMeanLatency>
-    ): JsonObject = Json.createObjectBuilder()
+    ): JsonObject = JSON.createObjectBuilder()
         .add("label", "Latency experienced by virtual users")
-        .add("data", Json.createArrayBuilder(latencies.map { it.meanLatency }).build())
+        .add("data", JSON.createArrayBuilder(latencies.map { it.meanLatency }).build())
         .add("backgroundColor", getColor(dataSize = latencies.size, opacity = 0.2))
         .add("borderColor", getColor(dataSize = latencies.size, opacity = 1.0))
         .add("borderWidth", 1)
@@ -61,7 +61,7 @@ internal class MeanLatencyChart {
     private fun getColor(dataSize: Int, opacity: Double): JsonArray {
         val normalEntry = "rgba(54, 162, 235, $opacity)"
         val lastEntry = "rgba(75, 192, 192, $opacity)"
-        val colorBuilder = Json.createArrayBuilder()
+        val colorBuilder = JSON.createArrayBuilder()
         (1 until dataSize).forEach { colorBuilder.add(normalEntry) }
         colorBuilder.add(lastEntry)
         return colorBuilder.build()

--- a/src/main/kotlin/com/atlassian/performance/tools/report/chart/SystemMetricsChart.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/chart/SystemMetricsChart.kt
@@ -2,9 +2,9 @@ package com.atlassian.performance.tools.report.chart
 
 import com.atlassian.performance.tools.infrastructure.api.metric.Dimension
 import com.atlassian.performance.tools.infrastructure.api.metric.SystemMetric
+import com.atlassian.performance.tools.report.JsonProviderSingleton.JSON
 import java.time.Instant
 import java.time.temporal.ChronoUnit
-import javax.json.Json
 import javax.json.JsonObject
 
 internal class SystemMetricsChart(
@@ -32,7 +32,7 @@ internal class SystemMetricsChart(
             .filter { it.dimension == dimension }
             .sortedBy { it.start }
         val chartData = Chart(plotValuesPerSystem(metrics))
-        return Json.createObjectBuilder()
+        return JSON.createObjectBuilder()
             .add("title", title)
             .add("axis", axis.toJson())
             .add("data", chartData.toJson())

--- a/src/main/kotlin/com/atlassian/performance/tools/report/chart/waterfall/WaterfallChart.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/chart/waterfall/WaterfallChart.kt
@@ -4,11 +4,11 @@ import com.atlassian.performance.tools.io.api.ensureParentDirectory
 import com.atlassian.performance.tools.jiraactions.api.ActionMetric
 import com.atlassian.performance.tools.jiraactions.api.w3c.PerformanceNavigationTiming
 import com.atlassian.performance.tools.jiraactions.api.w3c.PerformanceResourceTiming
+import com.atlassian.performance.tools.report.JsonProviderSingleton.JSON
 import com.atlassian.performance.tools.report.chart.waterfall.Phase.*
 import org.apache.logging.log4j.LogManager
 import java.io.File
 import java.time.Duration
-import javax.json.Json
 import javax.json.JsonArray
 import javax.json.JsonObject
 
@@ -229,9 +229,9 @@ internal class WaterfallChart {
         duration: Duration
     ): JsonObject {
         val size = Utils().toHumanReadableSize(requests.map { it.transferSize }.sum())
-        return Json.createObjectBuilder()
+        return JSON.createObjectBuilder()
             .add("display", true)
-            .add("text", Json.createArrayBuilder(listOf(
+            .add("text", JSON.createArrayBuilder(listOf(
                 "\"$actionLabel\" action requests waterfall chart",
                 "requests: ${requests.size}, total duration: ${duration.toMillis()} ms, total transfer: $size"
             )).build())
@@ -240,20 +240,20 @@ internal class WaterfallChart {
 
     private fun toJson(
         requests: Collection<ProcessingModel>
-    ): JsonObject = Json.createObjectBuilder()
-        .add("labels", Json.createArrayBuilder(requests.map { Utils().prettyPrint(it.address) }).build())
-        .add("fullLabels", Json.createArrayBuilder(requests.map { it.address }).build())
-        .add("initiatorTypes", Json.createArrayBuilder(requests.map { it.initiatorType }).build())
-        .add("transferSizes", Json.createArrayBuilder(requests.map { it.transferSize }).build())
-        .add("decodedBodySizes", Json.createArrayBuilder(requests.map { it.decodedBodySize }).build())
-        .add("totalDurations", Json.createArrayBuilder(requests.map { it.totalDuration.toMillis() }).build())
+    ): JsonObject = JSON.createObjectBuilder()
+        .add("labels", JSON.createArrayBuilder(requests.map { Utils().prettyPrint(it.address) }).build())
+        .add("fullLabels", JSON.createArrayBuilder(requests.map { it.address }).build())
+        .add("initiatorTypes", JSON.createArrayBuilder(requests.map { it.initiatorType }).build())
+        .add("transferSizes", JSON.createArrayBuilder(requests.map { it.transferSize }).build())
+        .add("decodedBodySizes", JSON.createArrayBuilder(requests.map { it.decodedBodySize }).build())
+        .add("totalDurations", JSON.createArrayBuilder(requests.map { it.totalDuration.toMillis() }).build())
         .add("datasets", getDatasets(requests))
         .build()
 
     private fun getDatasets(
         requests: Collection<ProcessingModel>
     ): JsonArray {
-        val datasetBuilder = Json.createArrayBuilder()
+        val datasetBuilder = JSON.createArrayBuilder()
         enumValues<Phase>().forEach {
             datasetBuilder.add(getDataset(it, requests))
         }
@@ -263,9 +263,9 @@ internal class WaterfallChart {
     private fun getDataset(
         phase: Phase,
         requests: Collection<ProcessingModel>
-    ): JsonObject = Json.createObjectBuilder()
+    ): JsonObject = JSON.createObjectBuilder()
         .add("label", phase.label)
         .add("backgroundColor", phase.color)
-        .add("data", Json.createArrayBuilder(requests.map { it.phases[phase]!!.toMillis() }).build())
+        .add("data", JSON.createArrayBuilder(requests.map { it.phases[phase]!!.toMillis() }).build())
         .build()
 }


### PR DESCRIPTION
I used DistributionComparisonTest to measure the gain in execution time.
Before:
![Screenshot 2023-10-06 at 16 11 40](https://github.com/atlassian/report/assets/50660179/d4cc66a1-f37b-439e-b48c-33aef3419f86)
![Screenshot 2023-10-06 at 16 14 53](https://github.com/atlassian/report/assets/50660179/67adf3be-9586-4a3f-8c4c-7c81ca2c459b)

After:
![Screenshot 2023-10-06 at 16 09 42](https://github.com/atlassian/report/assets/50660179/8093f671-64c7-4d84-814b-c67095086d76)
![Screenshot 2023-10-06 at 16 13 54](https://github.com/atlassian/report/assets/50660179/b5095159-ea37-4770-b1ea-8470fff5e509)
