### PR TITLE
Expose `RawCohortResult.cohort`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/report/compare/release-4.1.0...master
 
+### Added
+- Expose `RawCohortResult.cohort`.
+
 ## [4.1.0] - 2023-11-30
 [4.1.0]: https://github.com/atlassian/report/compare/release-4.0.0...release-4.1.0
 

--- a/src/main/kotlin/com/atlassian/performance/tools/report/api/result/RawCohortResult.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/report/api/result/RawCohortResult.kt
@@ -28,6 +28,11 @@ abstract class RawCohortResult private constructor() {
     abstract val failure: Exception?
 
     /**
+     * Textual description of the cohort, e.g. "9.12.0 on DC 2 nodes - experiment, sample 3".
+     */
+    abstract val cohort: String
+
+    /**
      * Prepares post-processed performance results.
      */
     abstract fun prepareForJudgement(
@@ -68,7 +73,7 @@ abstract class RawCohortResult private constructor() {
     }
 
     private class FullRawCohortResult(
-        private val cohort: String,
+        override val cohort: String,
         override val results: Path,
         format: MetricJsonFormat
     ) : RawCohortResult() {
@@ -113,7 +118,7 @@ abstract class RawCohortResult private constructor() {
     }
 
     private class FailedRawCohortResult(
-        private val cohort: String,
+        override val cohort: String,
         override val results: Path,
         override val failure: Exception
     ) : RawCohortResult() {
@@ -134,7 +139,7 @@ abstract class RawCohortResult private constructor() {
     }
 
     private class LegacyRawCohortResult(
-        private val cohort: String,
+        override val cohort: String,
         override val failure: Exception
     ) : RawCohortResult() {
 


### PR DESCRIPTION
`RawCohortResult` is more lightweight than `EdibleResult`, so sometimes we want to handle multiple raw results without ever calling `prepareForJudgement`. In those cases, distinguishing results by cohort label is very useful.